### PR TITLE
Don't fail deleting credentials if no secrets found to delete

### DIFF
--- a/__tests__/api/KeytarCredentialManager.test.ts
+++ b/__tests__/api/KeytarCredentialManager.test.ts
@@ -57,19 +57,6 @@ describe("KeytarCredentialManager", () => {
       expect(keytar.__getMockKeyring()).toEqual(expected);
     });
 
-    it("should fail removing non-existing credentials", async () => {
-      let err;
-
-      try {
-        await manager.delete(C.ACC4);
-      }
-      catch (e) {
-        err = e;
-      }
-      expect(err).toBeDefined();
-      expect(err).toMatchSnapshot();
-    });
-
     it("should retrieve credentials from the storage from the provided test service", async () => {
       let err;
       let result;
@@ -83,7 +70,7 @@ describe("KeytarCredentialManager", () => {
       expect(result).toEqual(C.PASS2);
     });
 
-    it("should fail load credentials that was not stored before", async () => {
+    it("should fail to load credentials that were not stored before", async () => {
       let err;
       let result;
       try {
@@ -95,6 +82,23 @@ describe("KeytarCredentialManager", () => {
       expect(err).toBeDefined();
       expect(result).toBeUndefined();
       expect(err).toMatchSnapshot();
+    });
+
+    it("should silently fail to remove non-existing credentials", async () => {
+      const deleteSpy = jest.spyOn(KeytarCredentialManager.prototype as any, "deleteCredentialsHelper");
+      let err;
+
+      try {
+        await manager.delete(C.ACC4);
+      }
+      catch (e) {
+        err = e;
+      }
+      expect(err).toBeUndefined();
+      expect(deleteSpy).toHaveBeenCalled();
+      await deleteSpy.mock.results[0].value.then((value: boolean) => {
+        expect(value).toBe(false);
+      });
     });
 
     it("should securely store credentials to the plugin service without any conflicts", async () => {

--- a/__tests__/api/__snapshots__/KeytarCredentialManager.test.ts.snap
+++ b/__tests__/api/__snapshots__/KeytarCredentialManager.test.ts.snap
@@ -1,5 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`KeytarCredentialManager Test Service should fail load credentials that was not stored before 1`] = `[Error: Unable to load credentials.]`;
-
-exports[`KeytarCredentialManager Test Service should fail removing non-existing credentials 1`] = `[Error: Unable to delete credentials.]`;
+exports[`KeytarCredentialManager Test Service should fail to load credentials that were not stored before 1`] = `[Error: Unable to load credentials.]`;

--- a/src/credentials/KeytarCredentialManager.ts
+++ b/src/credentials/KeytarCredentialManager.ts
@@ -81,14 +81,14 @@ export = class KeytarCredentialManager extends AbstractCredentialManager {
    * @returns {Promise<void>} A promise that the function has completed.
    */
   public async initialize(): Promise<void> {
-      try {
-          this.keytar = await import("keytar");
-      } catch (error) {
-          this.loadError = new ImperativeError({
-              msg: "Keytar not Installed",
-              causeErrors: error
-          });
-      }
+    try {
+      this.keytar = await import("keytar");
+    } catch (error) {
+      this.loadError = new ImperativeError({
+        msg: "Keytar not Installed",
+        causeErrors: error
+      });
+    }
   }
 
   /**
@@ -100,17 +100,10 @@ export = class KeytarCredentialManager extends AbstractCredentialManager {
    * @returns {Promise<void>} A promise that the function has completed.
    *
    * @throws {@link ImperativeError} if keytar is not defined.
-   * @throws {@link ImperativeError} when keytar.deletePassword returns false.
    */
   protected async deleteCredentials(account: string): Promise<void> {
     this.checkForKeytar();
-
-    if (!await this.deleteCredentialsHelper(account)) {
-      throw new ImperativeError({
-        msg: "Unable to delete credentials.",
-        additionalDetails: this.getMissingEntryMessage(account)
-      });
-    }
+    await this.deleteCredentialsHelper(account);
   }
 
   /**
@@ -215,17 +208,17 @@ export = class KeytarCredentialManager extends AbstractCredentialManager {
    * @throws {@link ImperativeError} when keytar is null or undefined.
    */
   private checkForKeytar(): void {
-      if (this.keytar == null) {
-          if (this.loadError == null) {
-              throw new ImperativeError({
-                  msg: "Keytar was not properly loaded due to an unknown cause."
-              }, {
-                  suppressReport: true
-              });
-          } else {
-              throw this.loadError;
-          }
+    if (this.keytar == null) {
+      if (this.loadError == null) {
+        throw new ImperativeError({
+          msg: "Keytar was not properly loaded due to an unknown cause."
+        }, {
+          suppressReport: true
+        });
+      } else {
+        throw this.loadError;
       }
+    }
   }
 
   private async deleteCredentialsHelper(account: string, skipPluginService?: boolean): Promise<boolean> {


### PR DESCRIPTION
The previous behavior was undesirable in the following scenarios:
* After installing the SCS plugin, someone wants to delete an insecure profile they had previously created. It's not intuitive to need to run the `scs update` command just to delete a profile. (See https://github.com/zowe/zowe-cli/issues/665.)
* Someone opens the Windows Credential Manager and manually removes the credentials stored by the SCS plugin.

In both these scenarios, the CLI profile associated with the missing credentials will be broken, so loading that profile should fail. But there is no reason that deleting it should fail, which would only make it harder to get out of a broken profile situation.

The `deleteCredentials` method will still fail if Keytar throws an error when attempting to delete secrets.