### PR TITLE
Clean up running of system tests in pipeline

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=http://registry.npmjs.org/
+@zowe:registry=https://zowe.jfrog.io/zowe/api/npm/npm-release/

--- a/__tests__/__src__/TestUtils.ts
+++ b/__tests__/__src__/TestUtils.ts
@@ -37,7 +37,7 @@ export function runCliScript(scriptPath: string, testEnvironment: ITestEnvironme
         // Execute the command synchronously
         return spawnSync("sh", [`${scriptPath}`].concat(args), {cwd: testEnvironment.workingDir, env: childEnv});
     } else {
-        throw new Error(`The script file  ${scriptPath} doesn't exist`);
+        throw new Error(`The script file ${scriptPath} doesn't exist`);
 
     }
 }

--- a/__tests__/__system__/cli/update/__scripts__/install_plugin.sh
+++ b/__tests__/__system__/cli/update/__scripts__/install_plugin.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-zowe plugins install $1
-
-exit $?

--- a/__tests__/__system__/cli/update/cli.scs.update.system.test.ts
+++ b/__tests__/__system__/cli/update/cli.scs.update.system.test.ts
@@ -35,13 +35,7 @@ describe("secure-credential-store update command", () => {
   });
 
   it("should update plain text profiles successfully", async () => {
-    let response;
-    // Install plugin
-    response = await runCliScript(__dirname + "/__scripts__/install_plugin.sh", TEST_ENV, ["../../../../"]);
-    // expect(response.stderr.toString()).toBe(""); // Do not check for stderr since there might be warnings
-    expect(response.stdout.toString()).toContain("Installed");
-
-    response = await runCliScript(__dirname + "/__scripts__/update_success.sh", TEST_ENV);
+    const response = await runCliScript(__dirname + "/__scripts__/update_success.sh", TEST_ENV);
     expect(response.stderr.toString()).toBe("");
     expect(response.stdout.toString()).toContain(`Profile ("${PROFILE_NAME}" of type "zosmf") successfully written`);
     expect(response.status).toBe(0);

--- a/jenkins/system_tests.sh
+++ b/jenkins/system_tests.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-# Unlock the keyring
-echo 'jenkins' | gnome-keyring-daemon --unlock
-
-# Run the tests
-npm run test:system


### PR DESCRIPTION
* Fix branch builds failing in Jenkins because plugin was getting installed 3 times
* Pull all @zowe packages from Zowe Artifactory instead of public NPM
* Rename "Integration Tests" to "System Tests" in the pipeline to be consistent with the project folder structure