### PR TITLE
Support installing the plugin offline

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "files": [
     "lib",
+    "prebuilds",
     "scripts/preinstall.js",
     "scripts/postinstall.js"
   ],

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "registry": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/"
   },
   "files": [
-    "lib"
+    "lib",
+    "scripts/preinstall.js",
+    "scripts/postinstall.js"
   ],
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -37,7 +39,8 @@
     "watch": "tsc --pretty --watch",
     "watch:test": "jest --watch",
     "installPlugin": "npm install && npm run clean && npm run build && zowe plugins install .",
-    "postinstall": "zowe config set CredentialManager @zowe/secure-credential-store-for-zowe-cli && echo \"The Secure Credential Store has been successfully installed. The CLI will now use the Node Keytar module to encrypt your local credentials. CLI Profiles that you have created will need to be updated because their credentials are stored in plain text and not accessible from the credential manager.  Refer to the available options in the help text to update profiles 'zowe scs update -h'.\" 1>&2",
+    "preinstall": "node scripts/preinstall.js",
+    "postinstall": "zowe config set CredentialManager @zowe/secure-credential-store-for-zowe-cli && node scripts/postinstall.js && echo \"The Secure Credential Store has been successfully installed. The CLI will now use the Node Keytar module to encrypt your local credentials. CLI Profiles that you have created will need to be updated because their credentials are stored in plain text and not accessible from the credential manager. Refer to the available options in the help text to update profiles 'zowe scs update -h'.\" 1>&2",
     "preuninstall": "zowe config reset CredentialManager",
     "postuninstall": "echo \"CLI Profiles that you have created will need to be recreated because their credentials are stored in the credential manager that has been uninstalled. Refer to the available options in the help text to create a new profile 'zowe profiles create zosmf-profile -h'.\" 1>&2"
   },

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,3 +1,13 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
 const fs = require("fs");
 const path = require("path");
 

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,26 @@
+const fs = require("fs");
+const path = require("path");
+
+// Function copied from prebuild-install
+function npmCache() {
+    const env = process.env;
+    const home = require('os').homedir;
+    return env.npm_config_cache ||
+        (env.APPDATA ? path.join(env.APPDATA, 'npm-cache') : path.join(home(), '.npm'));
+}
+
+// Delete .tar.gz files that we added to NPM cache during preinstall
+const cacheDir = path.join(npmCache(), "_prebuilds");
+if (fs.existsSync(cacheDir)) {
+    fs.readdirSync(cacheDir).forEach((filename) => {
+        if (filename.match(/.*-keytar-.*-node-.*\.tar\.gz/)) {
+            fs.unlinkSync(path.join(cacheDir, filename));
+        }
+    });
+}
+
+// Delete local prebuilds folder if empty
+const localDir = path.join(__dirname, "..", "prebuilds");
+if (fs.existsSync(localDir) && fs.readdirSync(localDir).length === 0) {
+    fs.rmdirSync(localDir);
+}

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,6 +1,17 @@
 const fs = require("fs");
 const path = require("path");
 
+// Check if local prebuilds folder exists
+const localDir = path.join(__dirname, "..", "prebuilds");
+if (!fs.existsSync(localDir)) {
+    process.exit(0);
+}
+
+// Delete local prebuilds folder if empty
+if (fs.readdirSync(localDir).length === 0) {
+    fs.rmdirSync(localDir);
+}
+
 // Function copied from prebuild-install
 function npmCache() {
     const env = process.env;
@@ -17,10 +28,4 @@ if (fs.existsSync(cacheDir)) {
             fs.unlinkSync(path.join(cacheDir, filename));
         }
     });
-}
-
-// Delete local prebuilds folder if empty
-const localDir = path.join(__dirname, "..", "prebuilds");
-if (fs.existsSync(localDir) && fs.readdirSync(localDir).length === 0) {
-    fs.rmdirSync(localDir);
 }

--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -1,0 +1,29 @@
+const fs = require("fs");
+const path = require("path");
+
+// Check if local prebuilds folder exists
+const localDir = path.join(__dirname, "..", "prebuilds");
+if (!fs.existsSync(localDir)) {
+    process.exit(0);
+}
+
+// Function copied from prebuild-install
+function npmCache() {
+    const env = process.env;
+    const home = require('os').homedir;
+    return env.npm_config_cache ||
+        (env.APPDATA ? path.join(env.APPDATA, 'npm-cache') : path.join(home(), '.npm'));
+}
+
+// Ensure that folder to store prebuilds exists in NPM cache
+const cacheDir = path.join(npmCache(), "_prebuilds");
+if (!fs.existsSync(cacheDir)) {
+    fs.mkdirSync(cacheDir);
+}
+
+// Move prebuilt .tar.gz files from local folder to NPM cache
+fs.readdirSync(localDir).forEach((filename) => {
+    if (filename.match(/.*-keytar-.*-node-.*\.tar\.gz/)) {
+        fs.renameSync(path.join(localDir, filename), path.join(cacheDir, filename));
+    }
+});

--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -1,3 +1,13 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
 const fs = require("fs");
 const path = require("path");
 


### PR DESCRIPTION
Fixes #9 and related to https://github.com/zowe/zowe-cli-standalone-package/issues/12

This adds a preinstall step to copy prebuilt native code for Keytar into the NPM cache, and a postinstall step to delete it afterwards. This tricks the `prebuild-install` module used by Keytar into thinking it has already downloaded the prebuilt code. These steps will only happen if the prebuilt code was bundled into the plugin TGZ, it won't affect how the plugin gets installed from public NPM.