### PR TITLE
Don't fail to load optional secure fields

### DIFF
--- a/__tests__/api/KeytarCredentialManager.test.ts
+++ b/__tests__/api/KeytarCredentialManager.test.ts
@@ -27,7 +27,7 @@ describe("KeytarCredentialManager", () => {
       keytar.__setMockKeyring(C.TEST_CREDENTIALS);
     });
 
-    it("should be an instance of AbrstractCredentialManager", () => {
+    it("should be an instance of AbstractCredentialManager", () => {
       expect(manager instanceof AbstractCredentialManager).toBe(true);
     });
 
@@ -83,11 +83,11 @@ describe("KeytarCredentialManager", () => {
       expect(result).toEqual(C.PASS2);
     });
 
-    it("should fail load credentials that was not stored before", async () => {
+    it("should fail to load credentials that were not stored before if required", async () => {
       let err;
       let result;
       try {
-        result = await manager.load(C.ACC4);
+        result = await manager.load(C.ACC4, false);
       }
       catch (e) {
         err = e;
@@ -95,6 +95,19 @@ describe("KeytarCredentialManager", () => {
       expect(err).toBeDefined();
       expect(result).toBeUndefined();
       expect(err).toMatchSnapshot();
+    });
+
+    it("should not fail to load credentials that were not stored before if optional", async () => {
+      let err;
+      let result;
+      try {
+        result = await manager.load(C.ACC4, true);
+      }
+      catch (e) {
+        err = e;
+      }
+      expect(err).toBeUndefined();
+      expect(result).toBeNull();
     });
 
     it("should securely store credentials to the plugin service without any conflicts", async () => {

--- a/src/credentials/KeytarCredentialManager.ts
+++ b/src/credentials/KeytarCredentialManager.ts
@@ -123,7 +123,7 @@ export = class KeytarCredentialManager extends AbstractCredentialManager {
    * @throws {@link ImperativeError} if keytar is not defined.
    * @throws {@link ImperativeError} when keytar.getPassword returns null or undefined.
    */
-  protected async loadCredentials(account: string): Promise<SecureCredential> {
+  protected async loadCredentials(account: string, optional?: boolean): Promise<SecureCredential> {
     this.checkForKeytar();
     // Helper function to handle all breaking changes
     const loadHelper = async (service: string) => {
@@ -171,7 +171,7 @@ export = class KeytarCredentialManager extends AbstractCredentialManager {
       }
     }
 
-    if (password == null) {
+    if (password == null && !optional) {
       throw new ImperativeError({
         msg: "Unable to load credentials.",
         additionalDetails: this.getMissingEntryMessage(account)


### PR DESCRIPTION
This should be merged after https://github.com/zowe/imperative/pull/366. It is part of the fix for https://github.com/zowe/imperative/issues/364.