### PR TITLE
Bundle Keytar binaries in pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,9 +70,8 @@ node('ca-jenkins-agent') {
     )
 
     // Build the application
-    pipeline.build(timeout: [
-        time: 10,
-        unit: 'MINUTES',
+    pipeline.build(
+        timeout: [ time: 10, unit: 'MINUTES' ],
         archiveOperation: {
             // Bundle Keytar binaries
             def packageJson = readJSON file: "package.json"
@@ -81,7 +80,7 @@ node('ca-jenkins-agent') {
                 sh "bash jenkins/bundleKeytar.sh \"${USERNAME}:${TOKEN}\" ${keytarVer}"
             }
         }
-    ])
+    )
 
     def TEST_ROOT = "__tests__/__results__"
     def UNIT_TEST_ROOT = "$TEST_ROOT/unit"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,7 @@ node('ca-jenkins-agent') {
             // Bundle Keytar binaries
             def packageJson = readJSON file: "package.json"
             def keytarVer = packageJson.dependencies['keytar']
-            withCredentials([usernamePassword(credentialsId: 'ZOWE_ROBOT_GITHUB', usernameVariable: 'USERNAME', passwordVariable: 'TOKEN')]) {
+            withCredentials([usernamePassword(credentialsId: 'zowe-robot-github', usernameVariable: 'USERNAME', passwordVariable: 'TOKEN')]) {
                 sh "bash jenkins/bundleKeytar.sh \"${USERNAME}:${TOKEN}\" ${keytarVer}"
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,7 +74,7 @@ node('ca-jenkins-agent') {
         timeout: [ time: 10, unit: 'MINUTES' ],
         archiveOperation: {
             // Bundle Keytar binaries
-            sh "sudo apt-get install jq"
+            sh "sudo apt-get install -y jq"
             def packageJson = readJSON file: "package.json"
             def keytarVer = packageJson.dependencies['keytar']
             withCredentials([usernamePassword(credentialsId: 'zowe-robot-github', usernameVariable: 'USERNAME', passwordVariable: 'TOKEN')]) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,6 +74,7 @@ node('ca-jenkins-agent') {
         timeout: [ time: 10, unit: 'MINUTES' ],
         archiveOperation: {
             // Bundle Keytar binaries
+            sh "sudo apt-get install jq"
             def packageJson = readJSON file: "package.json"
             def keytarVer = packageJson.dependencies['keytar']
             withCredentials([usernamePassword(credentialsId: 'zowe-robot-github', usernameVariable: 'USERNAME', passwordVariable: 'TOKEN')]) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,7 +74,6 @@ node('ca-jenkins-agent') {
         timeout: [ time: 10, unit: 'MINUTES' ],
         archiveOperation: {
             // Bundle Keytar binaries
-            sh "sudo apt-get install -y jq"
             def packageJson = readJSON file: "package.json"
             def keytarVer = packageJson.dependencies['keytar']
             withCredentials([usernamePassword(credentialsId: 'zowe-robot-github', usernameVariable: 'USERNAME', passwordVariable: 'TOKEN')]) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,14 +78,7 @@ node('ca-jenkins-agent') {
             def packageJson = readJSON file: "package.json"
             def keytarVer = packageJson.dependencies['keytar']
             withCredentials([usernamePassword(credentialsId: 'ZOWE_ROBOT_GITHUB', usernameVariable: 'USERNAME', passwordVariable: 'TOKEN')]) {
-                sh """
-    mkdir prebuilds && cd prebuilds &&
-    curl -s https://${USERNAME}:${TOKEN}@api.github.com/repos/atom/node-keytar/releases/tags/v${keytarVer} |
-        jq -c '.assets[] | select (.name | contains(\"node\"))' |
-        jq -r -c 'select (.browser_download_url) | .browser_download_url' |
-        while IFS=$\"\\n\" read -r c; do curl -sL -o `echo -n $(echo -n \$c | md5sum | cut -c1-6)'-'$(basename \$c)` \$c; done &&
-    cd ..
-    """
+                sh "bash jenkins/bundleKeytar.sh \"${USERNAME}:${TOKEN}\" ${keytarVer}"
             }
         }
     ])

--- a/__tests__/api/__snapshots__/KeytarCredentialManager.test.ts.snap
+++ b/__tests__/api/__snapshots__/KeytarCredentialManager.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`KeytarCredentialManager Test Service should fail to load credentials that were not stored before 1`] = `[Error: Unable to load credentials.]`;
+exports[`KeytarCredentialManager Test Service should fail to load credentials that were not stored before if required 1`] = `[Error: Unable to load credentials.]`;

--- a/jenkins/bundleKeytar.sh
+++ b/jenkins/bundleKeytar.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
-set -e
+set -ex
 
 mkdir prebuilds && cd prebuilds
 curl -fsL -o jq https://github.com/stedolan/jq/releases/latest/download/jq-linux64
 chmod +x ./jq
 
 curl -fs https://$1@api.github.com/repos/atom/node-keytar/releases/tags/v$2 |
-    jq -c '.assets[] | select (.name | contains("node"))' |
-    jq -r -c 'select (.browser_download_url) | .browser_download_url' |
+    ./jq -c '.assets[] | select (.name | contains("node"))' |
+    ./jq -r -c 'select (.browser_download_url) | .browser_download_url' |
     while IFS=$"\n" read -r c; do curl -sL -o `echo -n $(echo -n $c | md5sum | cut -c1-6)'-'$(basename $c)` $c; done
 
 rm ./jq

--- a/jenkins/bundleKeytar.sh
+++ b/jenkins/bundleKeytar.sh
@@ -2,8 +2,13 @@
 set -e
 
 mkdir prebuilds && cd prebuilds
-curl -s https://$1@api.github.com/repos/atom/node-keytar/releases/tags/v$2 |
+curl -fsLO jq https://github.com/stedolan/jq/releases/latest/download/jq-linux64
+chmod +x ./jq
+
+curl -fs https://$1@api.github.com/repos/atom/node-keytar/releases/tags/v$2 |
     jq -c '.assets[] | select (.name | contains("node"))' |
     jq -r -c 'select (.browser_download_url) | .browser_download_url' |
     while IFS=$"\n" read -r c; do curl -sL -o `echo -n $(echo -n $c | md5sum | cut -c1-6)'-'$(basename $c)` $c; done
+
+rm ./jq
 cd ..

--- a/jenkins/bundleKeytar.sh
+++ b/jenkins/bundleKeytar.sh
@@ -2,7 +2,7 @@
 set -e
 
 mkdir prebuilds && cd prebuilds
-curl -fsLO jq https://github.com/stedolan/jq/releases/latest/download/jq-linux64
+curl -fsL -o jq https://github.com/stedolan/jq/releases/latest/download/jq-linux64
 chmod +x ./jq
 
 curl -fs https://$1@api.github.com/repos/atom/node-keytar/releases/tags/v$2 |

--- a/jenkins/bundleKeytar.sh
+++ b/jenkins/bundleKeytar.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+
 mkdir prebuilds && cd prebuilds
 curl -s https://$1@api.github.com/repos/atom/node-keytar/releases/tags/v$2 |
     jq -c '.assets[] | select (.name | contains("node"))' |

--- a/jenkins/bundleKeytar.sh
+++ b/jenkins/bundleKeytar.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+mkdir prebuilds && cd prebuilds
+curl -s https://$1@api.github.com/repos/atom/node-keytar/releases/tags/v$2 |
+    jq -c '.assets[] | select (.name | contains("node"))' |
+    jq -r -c 'select (.browser_download_url) | .browser_download_url' |
+    while IFS=$"\n" read -r c; do curl -sL -o `echo -n $(echo -n $c | md5sum | cut -c1-6)'-'$(basename $c)` $c; done
+cd ..


### PR DESCRIPTION
Follow up to #10, which added a preinstall script to detect for bundled Keytar binaries. This PR bundles the binaries as a postbuild step in the pipeline.

Thanks to @awharn for the one-liner using `curl` and `jq` to download the artifacts from Keytar's GitHub releases. (⌐■_■)