### PR TITLE
Add pre-deploy step to bundle Keytar binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Secure Credential Store Plug-in for Zowe CLI will be documented in this file.
 
+## `4.0.3`
+
+- Bundle Keytar binaries in NPM package so that plugin can be installed offline. Thanks @tjohnsonBCM
+
 ## `4.0.2`
 
 - Fix error when loading optional secure fields (e.g., "keyPassphrase" in SSH profile). Thanks @tjohnsonBCM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Secure Credential Store Plug-in for Zowe CLI will be 
 
 ## `4.0.3`
 
-- Bundle Keytar binaries in NPM package so that plugin can be installed offline. Thanks @tjohnsonBCM
+- Bundle Keytar binaries in NPM package so that plugin can be installed offline. Thanks @awharn, @tjohnsonBCM
 
 ## `4.0.2`
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -154,7 +154,7 @@ node('ca-jenkins-agent') {
     pipeline.checkVulnerabilities()
 
     pipeline.createStage(
-        name: "Bundle Keytar binaries",
+        name: "Bundle Keytar Binaries",
         shouldExecute: {
             return pipeline.protectedBranches.isProtected(BRANCH_NAME)
         },

--- a/jenkins/bundleKeytar.sh
+++ b/jenkins/bundleKeytar.sh
@@ -8,7 +8,7 @@ chmod +x ./jq
 curl -fs https://$1@api.github.com/repos/atom/node-keytar/releases/tags/v$2 |
     ./jq -c '.assets[] | select (.name | contains("node"))' |
     ./jq -r -c 'select (.browser_download_url) | .browser_download_url' |
-    while IFS=$"\n" read -r c; do curl -sL -o `echo -n $(echo -n $c | md5sum | cut -c1-6)'-'$(basename $c)` $c; done
+    while IFS=$"\n" read -r c; do curl -fsL -o `echo -n $(echo -n $c | md5sum | cut -c1-6)'-'$(basename $c)` $c; done
 
 rm ./jq
 cd ..


### PR DESCRIPTION
Because the post-build step introduced in #14 didn't work. 😢 

This PR won't require a version bump, as it's only a fix for the Jenkins pipeline. 😸 