### PR TITLE
Node 16 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Secure Credential Store Plug-in for Zowe CLI will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Updated the Keytar dependency to v7.7 to be compatible with Node.js v16.
+
 ## `4.1.4`
 
 - BugFix: Updated the Keytar and prebuild-install dependencies to make offline install possible for npm@7 users.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,11 +19,7 @@ import org.zowe.pipelines.nodejs.models.SemverLevel
  */
 def PRODUCT_NAME = "Zowe CLI"
 
-node('ca-jenkins-agent') {
-    // This plugin's tests requires the CLI be installed, so install the CLI
-    sh "npm config set @zowe:registry https://zowe.jfrog.io/zowe/api/npm/npm-local-release"
-    sh "npm install --global @zowe/cli"
-
+node('zowe-jenkins-agent-dind') {
     // Initialize the pipeline
     def pipeline = new NodeJSPipeline(this)
 
@@ -55,7 +51,7 @@ node('ca-jenkins-agent') {
     ]
 
     // Initialize the pipeline library, should create 5 steps
-    pipeline.setup()
+    pipeline.setup(nodeJsVersion: 'v12.22.1')
 
     // Create a custom lint stage that runs immediately after the setup.
     pipeline.createStage(
@@ -132,6 +128,7 @@ node('ca-jenkins-agent') {
             JEST_STARE_RESULT_HTML: "index.html"
         ],
         operation: {
+            sh "npm install --global @zowe/cli"
             writeFile file: TEST_PROPERTIES_FILE, text: SYSTEM_TEST_PROPERTIES
             sh "npm run test:system"
         },

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,6 +20,10 @@ import org.zowe.pipelines.nodejs.models.SemverLevel
 def PRODUCT_NAME = "Zowe CLI"
 
 node('zowe-jenkins-agent-dind') {
+    // This plugin's tests requires the CLI be installed, so install the CLI
+    sh "npm config set @zowe:registry https://zowe.jfrog.io/zowe/api/npm/npm-local-release"
+    sh "npm install --global @zowe/cli"
+
     // Initialize the pipeline
     def pipeline = new NodeJSPipeline(this)
 
@@ -128,7 +132,6 @@ node('zowe-jenkins-agent-dind') {
             JEST_STARE_RESULT_HTML: "index.html"
         ],
         operation: {
-            sh "npm install --global @zowe/cli"
             writeFile file: TEST_PROPERTIES_FILE, text: SYSTEM_TEST_PROPERTIES
             sh "npm run test:system"
         },

--- a/jenkins/bundleKeytar.sh
+++ b/jenkins/bundleKeytar.sh
@@ -9,14 +9,9 @@ cd "$(git rev-parse --show-toplevel)"
 rm -rf prebuilds
 mkdir prebuilds && cd prebuilds
 
-curl -fsL -o jq https://github.com/stedolan/jq/releases/latest/download/jq-linux64
-chmod +x ./jq
-
 curl -fs https://$githubAuthHeader@api.github.com/repos/atom/node-keytar/releases/tags/v$keytarVersion |
-    ./jq -c '.assets[] | select (.name | contains("node"))' |
-    ./jq -cr 'select (.browser_download_url) | .browser_download_url' |
+    jq -r '.assets[] | select (.browser_download_url) | .browser_download_url' |
     while read -r bdu; do curl -fsLOJ $bdu; done
 
-rm ./jq
 tar -czvf ../keytar-prebuilds.tgz *
 cd ..

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "postuninstall": "echo \"CLI Profiles that you have created will need to be recreated because their credentials are stored in the credential manager that has been uninstalled. Refer to the available options in the help text to create a new profile 'zowe profiles create zosmf-profile -h'.\" 1>&2"
   },
   "dependencies": {
-    "keytar": "7.6.0"
+    "keytar": "7.7.0"
   },
   "peerDependencies": {
     "@zowe/cli": "^6.0.0",


### PR DESCRIPTION
Starting with v7.7, Keytar no longer requires a separate prebuild for each version of Node.js/Electron. Hopefully this is the last time we have to update the Keytar dependency to be compatible with a new Node version 🙂 
![image](https://user-images.githubusercontent.com/22344007/116586395-6926e300-a8e7-11eb-9849-5d3fdf040ad9.png)
