### PR TITLE
Don't republish Keytar prebuilds for existing version on Artifactory

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,6 @@
 
 @Library('shared-pipelines') import org.zowe.pipelines.nodejs.NodeJSPipeline
 
-import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 import org.zowe.pipelines.nodejs.models.SemverLevel
 
 /**
@@ -180,7 +179,7 @@ node('zowe-jenkins-agent-dind') {
                     sh "curl -f -u ${USERNAME}:${PASSWORD} --data-binary \"@keytar-prebuilds.tgz\" -H \"Content-Type: application/x-gzip\" -X PUT ${uploadUrlArtifactory}"
                 }
             } else {
-                Utils.markStageSkippedForConditional(STAGE_NAME)
+                echo "Skipping upload to Artifactory because \"keytar-${keytarVer}-prebuilds.tgz\" already exists"
             }
         }
     )


### PR DESCRIPTION
Fixes cURL command which was failing in the pipeline

[**Before**](https://wash.zowe.org:8443/blue/organizations/jenkins/zowe-cli-scs-plugin/detail/master/46/pipeline)
![image](https://user-images.githubusercontent.com/22344007/123433186-2ad13b80-d599-11eb-85ec-2cebfa2261e8.png)

[**After**](https://wash.zowe.org:8443/blue/organizations/jenkins/zowe-cli-scs-plugin/detail/dont-duplicate-prebuilds/4/pipeline/190)
![image](https://user-images.githubusercontent.com/22344007/123433035-07a68c00-d599-11eb-83f3-ad1d20a58013.png)
