### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,16 @@ Before you install and use the plug-in:
 
         gnome-keyring-daemon --start --components=secrets
         ```
+    
+### zLinux
+
+- Follow all installation steps above for Linux
+
+- Install the following packages:
+  - Python 3 (> 3.6.0)
+  - make
+  - gcc-c++
+  - libsecret-devel
 
 ## Installing
 

--- a/README.md
+++ b/README.md
@@ -110,9 +110,9 @@ Before you install and use the plug-in:
 
 - Install the following packages:
   - Python 3 (> 3.6.0)
-  - make
-  - gcc-c++
-  - libsecret-devel
+  - `make`
+  - `gcc-c++`
+  - `libsecret-devel`
 
 ## Installing
 


### PR DESCRIPTION
Improve the installation documentation to describe how to install on zLinux, where no prebuilt binary is available for keytar

Signed-off-by: Andrew W. Harn <andrew.harn@broadcom.com>